### PR TITLE
Fix for notification click from NotificationExtension

### DIFF
--- a/src/ios/APPLocalNotification.m
+++ b/src/ios/APPLocalNotification.m
@@ -518,8 +518,11 @@ UNNotificationPresentationOptions const OptionAlert = UNNotificationPresentation
 
     handler();
 
-    if ([toast.trigger isKindOfClass:UNPushNotificationTrigger.class])
-        return;
+    // KOMED: This code prevents notification click working from notification extension
+    // the trigger type cannot be changed on NotificationExtension and there is no known
+    // reason why UNPushNotificationTrigger notifications should be ignored here.
+    //    if ([toast.trigger isKindOfClass:UNPushNotificationTrigger.class])
+    //        return;
 
     NSMutableDictionary* data = [[NSMutableDictionary alloc] init];
     NSString* action          = response.actionIdentifier;


### PR DESCRIPTION
Commenting out this code allows notification click working properly and opening a correct chat. Otherwise only Komed app is opened but redirect to chat is not working.